### PR TITLE
Fix compare map when the values are equal as JSON (after marshaling)

### DIFF
--- a/json_diff.go
+++ b/json_diff.go
@@ -2,6 +2,7 @@
 package jsondiff
 
 import (
+	"encoding/json"
 	"sort"
 	"strconv"
 	"strings"
@@ -10,10 +11,12 @@ import (
 // Diff compare two jsons map and returns the fields names that has been changed.
 // If input maps are equal, all return values will be empty.
 func Diff(firstJson map[string]interface{}, secondJson map[string]interface{}) []string {
+	firstJsonCopy := copyMapByte(firstJson)
+	secondJsonCopy := copyMapByte(secondJson)
 
 	changesSet := make(map[string]struct{})
-	compare(firstJson, secondJson, "", changesSet)
-	compare(secondJson, firstJson, "", changesSet)
+	compare(firstJsonCopy, secondJsonCopy, "", changesSet)
+	compare(secondJsonCopy, firstJsonCopy, "", changesSet)
 
 	changes := make([]string, 0)
 	for key := range changesSet {
@@ -66,6 +69,15 @@ func copyMap(m map[string]interface{}) map[string]interface{} {
 	}
 
 	return cp
+}
+
+func copyMapByte(m map[string]interface{}) map[string]interface{} {
+	copy := make(map[string]interface{})
+	if len(m) > 0 {
+		dataJson, _ := json.Marshal(m)
+		_ = json.Unmarshal(dataJson, &copy)
+	}
+	return copy
 }
 
 func removeNotAllowedFieldsFromPath(data map[string]interface{}, path string, allowedFields map[string]struct{}) {

--- a/json_diff_test.go
+++ b/json_diff_test.go
@@ -27,6 +27,39 @@ func TestShouldReturnFieldWhenValuesDiffer(t *testing.T) {
 	}
 }
 
+func TestDiffShouldReturnEmptyWhenArrayMatchButTypeIsDiffBeforeUnmarshal(t *testing.T) {
+
+	value := map[string]interface{}{
+		"num": 5.10,
+		"list": []interface{}{
+			map[string]interface{}{
+				"str": "a",
+			},
+			map[string]interface{}{
+				"str": "b",
+			},
+		},
+	}
+	value2 := map[string]interface{}{
+		"num": 5.10,
+		"list": []map[string]interface{}{
+			{
+				"str": "a",
+			},
+			{
+				"str": "b",
+			},
+		},
+	}
+
+	expected := []string{}
+	actual := jsondiff.Diff(value, value2)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Error("Test failed. Expected", expected, "but returned", actual)
+	}
+}
+
 func TestShouldReturnEmptyWhenValuesMatch(t *testing.T) {
 	value := map[string]interface{}{
 		"num": 6.13,
@@ -142,7 +175,7 @@ func TestShouldReturnFieldWhenTheSecondArrayHasDifferentElement(t *testing.T) {
 		"num": 6.13,
 	}
 
-	expected := []string{"str"}
+	expected := []string{"str[1]"}
 	actual := jsondiff.Diff(value, value2)
 
 	if !reflect.DeepEqual(expected, actual) {
@@ -161,7 +194,7 @@ func TestShouldReturnFieldWhenTheElementsOfAnArrayDoesNotMatch(t *testing.T) {
 		"num": 6.13,
 	}
 
-	expected := []string{"str"}
+	expected := []string{"str[1]"}
 	actual := jsondiff.Diff(value, value2)
 
 	if !reflect.DeepEqual(expected, actual) {
@@ -246,7 +279,7 @@ func TestShouldReturnFielsdWhenMoreThanOneFieldIsDifferent(t *testing.T) {
 		"num":   2,
 	}
 
-	expected := []string{"array", "json.num", "num", "str"}
+	expected := []string{"array[1]", "json.num", "num", "str"}
 	actual := jsondiff.Diff(value, value2)
 
 	if !reflect.DeepEqual(expected, actual) {
@@ -673,6 +706,48 @@ func TestShouldReturnEmptyOldAndNewValuesWhenDoesNotHasDiff(t *testing.T) {
 	expectedNew := map[string]interface{}{}
 
 	actualDiff, actualOld, actualNew := jsondiff.DiffWithValues(value, value)
+
+	if !reflect.DeepEqual(expectedDiff, actualDiff) {
+		t.Error("Test failed. Expected", expectedDiff, "but returned", actualDiff)
+	}
+	if !reflect.DeepEqual(expectedOld, actualOld) {
+		t.Error("Test failed. Expected", expectedOld, "but returned", actualOld)
+	}
+	if !reflect.DeepEqual(expectedNew, actualNew) {
+		t.Error("Test failed. Expected", expectedNew, "but returned", actualNew)
+	}
+}
+
+func TestDiffWithValuesShouldReturnEmptyWhenArrayMatchButTypeIsDiffBeforeUnmarshal(t *testing.T) {
+
+	value := map[string]interface{}{
+		"num": 5.10,
+		"list": []interface{}{
+			map[string]interface{}{
+				"str": "a",
+			},
+			map[string]interface{}{
+				"str": "b",
+			},
+		},
+	}
+	value2 := map[string]interface{}{
+		"num": 5.10,
+		"list": []map[string]interface{}{
+			{
+				"str": "a",
+			},
+			{
+				"str": "b",
+			},
+		},
+	}
+
+	expectedDiff := []string{}
+	expectedOld := map[string]interface{}{}
+	expectedNew := map[string]interface{}{}
+
+	actualDiff, actualOld, actualNew := jsondiff.DiffWithValues(value, value2)
 
 	if !reflect.DeepEqual(expectedDiff, actualDiff) {
 		t.Error("Test failed. Expected", expectedDiff, "but returned", actualDiff)


### PR DESCRIPTION
We got the case where we have two maps with one array field as `[]interface{}` and other with `[]map[string]interface{}`, but as `json` both match. So, it's safe make a copy/marshaling before get the `diff`. 